### PR TITLE
リザルト画面を修正

### DIFF
--- a/src/app/confirm_onkatsu_result/page.tsx
+++ b/src/app/confirm_onkatsu_result/page.tsx
@@ -4,18 +4,13 @@ import { ResultScreen } from "@/components/ResultScreen";
 import onsenStamp from "@/assets/23d72f267674d7a86e5a4d3966ba367d52634bd9.png";
 
 export default function ConfirmOnkatsuResult() {
-  const expGained = 50; // 獲得経験値の例
-  const levelUp = true; // レベルアップしたかどうかの例
-  const newLevel = 6; // 新しいレベルの例
+  const expGained = 50;
+  const levelUp = false;
   const character = {
-    name: "温泉ちゃん",
-    type: "onsen-chan",
+    name: "もちもちうさぎ",
     level: 5,
     exp: 150,
     maxExp: 200,
-    happiness: 80,
-    stamina: 60,
-    onsenCount: 3,
   };
 
   const acquiredStamp = {
@@ -31,7 +26,6 @@ export default function ConfirmOnkatsuResult() {
     <ResultScreen
       expGained={expGained}
       levelUp={levelUp}
-      newLevel={newLevel}
       character={character}
       acquiredStamp={acquiredStamp}
       onContinue={handleContinue}

--- a/src/app/confirm_onkatsu_result/page.tsx
+++ b/src/app/confirm_onkatsu_result/page.tsx
@@ -2,14 +2,13 @@
 
 import { ResultScreen } from "@/components/ResultScreen";
 import onsenStamp from "@/assets/23d72f267674d7a86e5a4d3966ba367d52634bd9.png";
-import characterImage from '@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png';
 
 export default function ConfirmOnkatsuResult() {
   const expGained = 50;
   const levelUp = false;
   const character = {
     name: "もちもちうさぎ",
-    image: characterImage.src,
+    type: "sakura-san",
     level: 5,
     exp: 150,
     maxExp: 200,

--- a/src/app/confirm_onkatsu_result/page.tsx
+++ b/src/app/confirm_onkatsu_result/page.tsx
@@ -1,5 +1,40 @@
+"use client";
+
+import { ResultScreen } from "@/components/ResultScreen";
+import onsenStamp from "@/assets/23d72f267674d7a86e5a4d3966ba367d52634bd9.png";
+
 export default function ConfirmOnkatsuResult() {
+  const expGained = 50; // 獲得経験値の例
+  const levelUp = true; // レベルアップしたかどうかの例
+  const newLevel = 6; // 新しいレベルの例
+  const character = {
+    name: "温泉ちゃん",
+    type: "onsen-chan",
+    level: 5,
+    exp: 150,
+    maxExp: 200,
+    happiness: 80,
+    stamina: 60,
+    onsenCount: 3,
+  };
+
+  const acquiredStamp = {
+    name: "温泉スタンプ",
+    icon: onsenStamp.src,
+  };
+
+  const handleContinue = () => {
+    console.log("続けるボタンが押されました");
+  };
+
   return (
-    <>リザルト確認画面</>
-  )
+    <ResultScreen
+      expGained={expGained}
+      levelUp={levelUp}
+      newLevel={newLevel}
+      character={character}
+      acquiredStamp={acquiredStamp}
+      onContinue={handleContinue}
+    />
+  );
 }

--- a/src/app/confirm_onkatsu_result/page.tsx
+++ b/src/app/confirm_onkatsu_result/page.tsx
@@ -2,12 +2,14 @@
 
 import { ResultScreen } from "@/components/ResultScreen";
 import onsenStamp from "@/assets/23d72f267674d7a86e5a4d3966ba367d52634bd9.png";
+import characterImage from '@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png';
 
 export default function ConfirmOnkatsuResult() {
   const expGained = 50;
   const levelUp = false;
   const character = {
     name: "もちもちうさぎ",
+    image: characterImage.src,
     level: 5,
     exp: 150,
     maxExp: 200,
@@ -18,7 +20,7 @@ export default function ConfirmOnkatsuResult() {
     icon: onsenStamp.src,
   };
 
-  const handleContinue = () => {
+  const handleNavigateToDecoration = () => {
     console.log("キャラクター画面へ移動");
   };
 
@@ -28,7 +30,7 @@ export default function ConfirmOnkatsuResult() {
       levelUp={levelUp}
       character={character}
       acquiredStamp={acquiredStamp}
-      onContinue={handleContinue}
+      onNavigateToDecoration={handleNavigateToDecoration}
     />
   );
 }

--- a/src/app/confirm_onkatsu_result/page.tsx
+++ b/src/app/confirm_onkatsu_result/page.tsx
@@ -24,7 +24,7 @@ export default function ConfirmOnkatsuResult() {
   };
 
   const handleContinue = () => {
-    console.log("続けるボタンが押されました");
+    console.log("キャラクター画面へ移動");
   };
 
   return (

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -5,12 +5,16 @@ import { Badge } from './ui/badge';
 import { Progress } from './ui/progress';
 import { Star, Stamp, ArrowUp } from 'lucide-react';
 import noiseTexture from '@/assets/221bcc06007de28e2dedf86e88d0a2798eac78e7.png';
+import beppyonImage from "@/assets/3c6e9e82c814a4dcb5208e61977d5118a50e6a2c.png";
+import yuttsuraImage from "@/assets/cc82c1498637df3406caa6867e011e9f0b8813d7.png";
+import kawaiiImage from "@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png";
+import { type } from 'os';
 
 interface ResultScreenProps {
   expGained: number;
   levelUp: boolean;
   newLevel?: number;
-  character: { image: string; name: string; level: number; exp: number; maxExp: number };
+  character: { name: string; type: string; level: number; exp: number; maxExp: number };
   acquiredStamp: { name: string; icon: string };
   onNavigateToDecoration: () => void;
 }
@@ -23,6 +27,22 @@ export function ResultScreen({
   acquiredStamp,
   onNavigateToDecoration
 }: ResultScreenProps) {
+
+  // キャラクターの種類に応じて画像を選択
+  const getCharacterImage = () => {
+    switch (character.type) {
+      case "onsen-chan":
+        return beppyonImage;
+      case "yuzu-kun":
+        return yuttsuraImage;
+      case "sakura-san":
+        return kawaiiImage;
+      default:
+        return beppyonImage;
+    }
+  };
+
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-app-base via-app-main-dark to-app-main relative overflow-hidden">
       <div className="flex flex-col items-center justify-center min-h-screen p-4">
@@ -45,7 +65,7 @@ export function ResultScreen({
             <CardContent className="pt-6">
               <div className="text-center">
                 <img
-                  src={character.image}
+                  src={getCharacterImage().src}
                   alt={character.name}
                   className="w-24 h-24 mx-auto object-contain mb-4"
                 />

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -3,15 +3,12 @@ import { Button } from './ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Badge } from './ui/badge';
 import { Progress } from './ui/progress';
-import { ImageWithFallback } from './figma/ImageWithFallback';
-import { Star, Stamp, ArrowUp, Heart, Zap } from 'lucide-react';
+import { Star, Stamp, ArrowUp } from 'lucide-react';
 import characterImage from '@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png';
 import stampImage from '@/assets/a8b69e84e6c8ec654b2bdf9a79607a4db01624d6.png';
 import noiseTexture from '@/assets/221bcc06007de28e2dedf86e88d0a2798eac78e7.png';
 
 interface ResultScreenProps {
-  timeSpent: number;
-  onsen: { name: string; image: string };
   expGained: number;
   levelUp: boolean;
   newLevel?: number;
@@ -20,9 +17,7 @@ interface ResultScreenProps {
   onContinue: () => void;
 }
 
-export function ResultScreen({ 
-  timeSpent, 
-  onsen, 
+export function ResultScreen({
   expGained, 
   levelUp, 
   newLevel, 

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -1,20 +1,25 @@
-import React from 'react';
-import { Button } from './ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
-import { Badge } from './ui/badge';
-import { Progress } from './ui/progress';
-import { Star, Stamp, ArrowUp } from 'lucide-react';
-import noiseTexture from '@/assets/221bcc06007de28e2dedf86e88d0a2798eac78e7.png';
+import React from "react";
+import { Button } from "./ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Badge } from "./ui/badge";
+import { Progress } from "./ui/progress";
+import { Star, Stamp, ArrowUp } from "lucide-react";
+import noiseTexture from "@/assets/221bcc06007de28e2dedf86e88d0a2798eac78e7.png";
 import beppyonImage from "@/assets/3c6e9e82c814a4dcb5208e61977d5118a50e6a2c.png";
 import yuttsuraImage from "@/assets/cc82c1498637df3406caa6867e011e9f0b8813d7.png";
 import kawaiiImage from "@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png";
-import { type } from 'os';
 
 interface ResultScreenProps {
   expGained: number;
   levelUp: boolean;
   newLevel?: number;
-  character: { name: string; type: string; level: number; exp: number; maxExp: number };
+  character: {
+    name: string;
+    type: string;
+    level: number;
+    exp: number;
+    maxExp: number;
+  };
   acquiredStamp: { name: string; icon: string };
   onNavigateToDecoration: () => void;
 }
@@ -25,9 +30,8 @@ export function ResultScreen({
   newLevel,
   character,
   acquiredStamp,
-  onNavigateToDecoration
+  onNavigateToDecoration,
 }: ResultScreenProps) {
-
   // キャラクターの種類に応じて画像を選択
   const getCharacterImage = () => {
     switch (character.type) {
@@ -41,7 +45,6 @@ export function ResultScreen({
         return beppyonImage;
     }
   };
-
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-app-base via-app-main-dark to-app-main relative overflow-hidden">
@@ -76,9 +79,13 @@ export function ResultScreen({
                   <div className="flex items-center justify-between mb-2">
                     <div className="flex items-center">
                       <Star className="h-5 w-5 text-app-accent-1-dark mr-2" />
-                      <span className="text-sm text-app-base-light">獲得経験値</span>
+                      <span className="text-sm text-app-base-light">
+                        獲得経験値
+                      </span>
                     </div>
-                    <span className="font-bold text-app-accent-1-dark">+{expGained} EXP</span>
+                    <span className="font-bold text-app-accent-1-dark">
+                      +{expGained} EXP
+                    </span>
                   </div>
                   <Progress
                     value={(expGained / 100) * 100}
@@ -126,22 +133,24 @@ export function ResultScreen({
                           className="absolute inset-0 w-24 h-24 opacity-25 pointer-events-none z-20"
                           style={{
                             backgroundImage: `url(${noiseTexture})`,
-                            backgroundSize: '100px 100px',
-                            backgroundRepeat: 'repeat',
-                            mixBlendMode: 'screen',
+                            backgroundSize: "100px 100px",
+                            backgroundRepeat: "repeat",
+                            mixBlendMode: "screen",
                             mask: `url(${acquiredStamp.icon})`,
-                            maskSize: 'contain',
-                            maskRepeat: 'no-repeat',
-                            maskPosition: 'center',
+                            maskSize: "contain",
+                            maskRepeat: "no-repeat",
+                            maskPosition: "center",
                             WebkitMask: `url(${acquiredStamp.icon})`,
-                            WebkitMaskSize: 'contain',
-                            WebkitMaskRepeat: 'no-repeat',
-                            WebkitMaskPosition: 'center'
+                            WebkitMaskSize: "contain",
+                            WebkitMaskRepeat: "no-repeat",
+                            WebkitMaskPosition: "center",
                           }}
                         />
                       </div>
                     </div>
-                    <p className="font-medium text-app-base mb-1">{acquiredStamp.name}</p>
+                    <p className="font-medium text-app-base mb-1">
+                      {acquiredStamp.name}
+                    </p>
                     <Badge className="bg-app-main">新規獲得</Badge>
                   </div>
                 </div>
@@ -149,11 +158,7 @@ export function ResultScreen({
             </CardContent>
           </Card>
 
-          <Button
-            size="lg"
-            className="w-full"
-            onClick={onNavigateToDecoration}
-          >
+          <Button size="lg" className="w-full" onClick={onNavigateToDecoration}>
             キャラクター画面に戻る
           </Button>
         </div>

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -121,23 +121,6 @@ export function ResultScreen({
                           WebkitMaskPosition: 'center'
                         }}
                       />
-
-                      {/* 印影効果 */}
-                      <div 
-                        className="absolute inset-0 w-24 h-24 opacity-25 pointer-events-none z-15"
-                        style={{
-                          background: `radial-gradient(ellipse at center, transparent 50%, rgba(93, 104, 138, 0.4) 65%, rgba(93, 104, 138, 0.6) 75%, transparent 90%)`,
-                          mixBlendMode: 'multiply',
-                          mask: `url(${stampImage})`,
-                          maskSize: 'contain',
-                          maskRepeat: 'no-repeat',
-                          maskPosition: 'center',
-                          WebkitMask: `url(${stampImage})`,
-                          WebkitMaskSize: 'contain',
-                          WebkitMaskRepeat: 'no-repeat',
-                          WebkitMaskPosition: 'center'
-                        }}
-                      />
                     </div>
                   </div>
                   <p className="font-medium text-app-base mb-1">{acquiredStamp.name}</p>

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Badge } from './ui/badge';
 import { Progress } from './ui/progress';
 import { Star, Stamp, ArrowUp } from 'lucide-react';
-import characterImage from '@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png';
 import stampImage from '@/assets/a8b69e84e6c8ec654b2bdf9a79607a4db01624d6.png';
 import noiseTexture from '@/assets/221bcc06007de28e2dedf86e88d0a2798eac78e7.png';
 
@@ -12,18 +11,18 @@ interface ResultScreenProps {
   expGained: number;
   levelUp: boolean;
   newLevel?: number;
-  character: { name: string; level: number; exp: number; maxExp: number };
+  character: { image: string; name: string; level: number; exp: number; maxExp: number };
   acquiredStamp: { name: string; icon: string };
-  onContinue: () => void;
+  onNavigateToDecoration: () => void;
 }
 
 export function ResultScreen({
-  expGained, 
-  levelUp, 
-  newLevel, 
+  expGained,
+  levelUp,
+  newLevel,
   character,
   acquiredStamp,
-  onContinue 
+  onNavigateToDecoration
 }: ResultScreenProps) {
   return (
     <div className="min-h-screen bg-gradient-to-b from-app-base via-app-main-dark to-app-main relative overflow-hidden">
@@ -43,98 +42,98 @@ export function ResultScreen({
             <h2 className="text-2xl text-white">オンカツ完了！</h2>
           </div>
 
-        <Card className="mb-6">
-          <CardContent className="pt-6">
-            <div className="text-center">
-              <img
-                src={characterImage.src}
-                alt={character.name}
-                className="w-24 h-24 mx-auto object-contain mb-4"
-              />
-              <h3 className="text-xl font-bold mb-6">{character.name}</h3>
-              
-              {/* 獲得経験値プログレスバー */}
-              <div className="mb-4">
-                <div className="flex items-center justify-between mb-2">
-                  <div className="flex items-center">
-                    <Star className="h-5 w-5 text-app-accent-1-dark mr-2" />
-                    <span className="text-sm text-app-base-light">獲得経験値</span>
-                  </div>
-                  <span className="font-bold text-app-accent-1-dark">+{expGained} EXP</span>
-                </div>
-                <Progress 
-                  value={(expGained / 100) * 100} 
-                  className="h-3 bg-app-accent-2-light"
+          <Card className="mb-6">
+            <CardContent className="pt-6">
+              <div className="text-center">
+                <img
+                  src={character.image}
+                  alt={character.name}
+                  className="w-24 h-24 mx-auto object-contain mb-4"
                 />
-                <div className="flex justify-between text-xs text-app-base-light mt-1">
-                  <span>0</span>
-                  <span>{expGained} / 100</span>
+                <h3 className="text-xl font-bold mb-6">{character.name}</h3>
+
+                {/* 獲得経験値プログレスバー */}
+                <div className="mb-4">
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center">
+                      <Star className="h-5 w-5 text-app-accent-1-dark mr-2" />
+                      <span className="text-sm text-app-base-light">獲得経験値</span>
+                    </div>
+                    <span className="font-bold text-app-accent-1-dark">+{expGained} EXP</span>
+                  </div>
+                  <Progress
+                    value={(expGained / 100) * 100}
+                    className="h-3 bg-app-accent-2-light"
+                  />
+                  <div className="flex justify-between text-xs text-app-base-light mt-1">
+                    <span>0</span>
+                    <span>{expGained} / 100</span>
+                  </div>
                 </div>
               </div>
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
 
-        <Card className="mb-6">
-          <CardHeader>
-            <CardTitle className="text-center flex items-center justify-center">
-              <Stamp className="h-5 w-5 mr-2 text-app-base" />
-              獲得スタンプ
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="text-center">
-              <div className="flex justify-center">
-                <div className="p-6 bg-app-accent-1-light rounded-lg">
-                  {/* リアルなスタンプ表示 */}
-                  <div className="relative mb-3 flex justify-center">
-                    <div className="relative w-24 h-24">
-                      {/* スタンプ画像 */}
-                      <img
-                        src={stampImage.src}
-                        alt="温泉スタンプ"
-                        className="w-24 h-24 object-contain relative z-10"
-                        style={{
-                          filter: `
+          <Card className="mb-6">
+            <CardHeader>
+              <CardTitle className="text-center flex items-center justify-center">
+                <Stamp className="h-5 w-5 mr-2 text-app-base" />
+                獲得スタンプ
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-center">
+                <div className="flex justify-center">
+                  <div className="p-6 bg-app-accent-1-light rounded-lg">
+                    {/* リアルなスタンプ表示 */}
+                    <div className="relative mb-3 flex justify-center">
+                      <div className="relative w-24 h-24">
+                        {/* スタンプ画像 */}
+                        <img
+                          src={stampImage.src}
+                          alt="温泉スタンプ"
+                          className="w-24 h-24 object-contain relative z-10"
+                          style={{
+                            filter: `
                             contrast(1.2) 
                             brightness(0.9)
                             sepia(0.1)
                           `,
-                        }}
-                      />
-                      
-                      {/* 白いノイズテクスチャオーバーレイ */}
-                      <div 
-                        className="absolute inset-0 w-24 h-24 opacity-25 pointer-events-none z-20"
-                        style={{
-                          backgroundImage: `url(${noiseTexture})`,
-                          backgroundSize: '100px 100px',
-                          backgroundRepeat: 'repeat',
-                          mixBlendMode: 'screen',
-                          mask: `url(${stampImage})`,
-                          maskSize: 'contain',
-                          maskRepeat: 'no-repeat',
-                          maskPosition: 'center',
-                          WebkitMask: `url(${stampImage})`,
-                          WebkitMaskSize: 'contain',
-                          WebkitMaskRepeat: 'no-repeat',
-                          WebkitMaskPosition: 'center'
-                        }}
-                      />
+                          }}
+                        />
+
+                        {/* 白いノイズテクスチャオーバーレイ */}
+                        <div
+                          className="absolute inset-0 w-24 h-24 opacity-25 pointer-events-none z-20"
+                          style={{
+                            backgroundImage: `url(${noiseTexture})`,
+                            backgroundSize: '100px 100px',
+                            backgroundRepeat: 'repeat',
+                            mixBlendMode: 'screen',
+                            mask: `url(${stampImage})`,
+                            maskSize: 'contain',
+                            maskRepeat: 'no-repeat',
+                            maskPosition: 'center',
+                            WebkitMask: `url(${stampImage})`,
+                            WebkitMaskSize: 'contain',
+                            WebkitMaskRepeat: 'no-repeat',
+                            WebkitMaskPosition: 'center'
+                          }}
+                        />
+                      </div>
                     </div>
+                    <p className="font-medium text-app-base mb-1">{acquiredStamp.name}</p>
+                    <Badge className="bg-app-main">新規獲得</Badge>
                   </div>
-                  <p className="font-medium text-app-base mb-1">{acquiredStamp.name}</p>
-                  <Badge className="bg-app-main">新規獲得</Badge>
                 </div>
               </div>
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
 
-          <Button 
-            size="lg" 
+          <Button
+            size="lg"
             className="w-full"
-            onClick={onContinue}
+            onClick={onNavigateToDecoration}
           >
             キャラクター画面に戻る
           </Button>

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Badge } from './ui/badge';
 import { Progress } from './ui/progress';
 import { Star, Stamp, ArrowUp } from 'lucide-react';
-import stampImage from '@/assets/a8b69e84e6c8ec654b2bdf9a79607a4db01624d6.png';
 import noiseTexture from '@/assets/221bcc06007de28e2dedf86e88d0a2798eac78e7.png';
 
 interface ResultScreenProps {
@@ -90,7 +89,7 @@ export function ResultScreen({
                       <div className="relative w-24 h-24">
                         {/* スタンプ画像 */}
                         <img
-                          src={stampImage.src}
+                          src={acquiredStamp.icon}
                           alt="温泉スタンプ"
                           className="w-24 h-24 object-contain relative z-10"
                           style={{
@@ -110,11 +109,11 @@ export function ResultScreen({
                             backgroundSize: '100px 100px',
                             backgroundRepeat: 'repeat',
                             mixBlendMode: 'screen',
-                            mask: `url(${stampImage})`,
+                            mask: `url(${acquiredStamp.icon})`,
                             maskSize: 'contain',
                             maskRepeat: 'no-repeat',
                             maskPosition: 'center',
-                            WebkitMask: `url(${stampImage})`,
+                            WebkitMask: `url(${acquiredStamp.icon})`,
                             WebkitMaskSize: 'contain',
                             WebkitMaskRepeat: 'no-repeat',
                             WebkitMaskPosition: 'center'

--- a/src/components/ResultScreen.tsx
+++ b/src/components/ResultScreen.tsx
@@ -47,7 +47,7 @@ export function ResultScreen({
           <CardContent className="pt-6">
             <div className="text-center">
               <img
-                src={characterImage}
+                src={characterImage.src}
                 alt={character.name}
                 className="w-24 h-24 mx-auto object-contain mb-4"
               />
@@ -91,7 +91,7 @@ export function ResultScreen({
                     <div className="relative w-24 h-24">
                       {/* スタンプ画像 */}
                       <img
-                        src={stampImage}
+                        src={stampImage.src}
                         alt="温泉スタンプ"
                         className="w-24 h-24 object-contain relative z-10"
                         style={{


### PR DESCRIPTION
closes #23

## やったこと

- [http://localhost:3000/confirm_onkatsu_result](http://localhost:3000/confirm_onkatsu_result)で入浴結果のリザルト画面を確認できるようにした
- スタンプ背景の陰影の削除
- 画像読み込みの正常化
- 一部変数の名称変更
- 使用されていないimportや変数の削除
- キャラクターの画像の表示ロジックの修正

## レビューしてほしいこと

- Figma Makeと同じ挙動になっているかどうか
- イベントハンドラが全て正常に発火すること
- キャラクターの画像の表示ロジックに問題はないか

## 備考

## 作業結果の参考画像
<img width="531" height="817" alt="SS 67" src="https://github.com/user-attachments/assets/dae0d298-00b0-41c7-9c7f-658b474f1fce" />
<img width="518" height="820" alt="SS 66" src="https://github.com/user-attachments/assets/8fce46cd-4a8c-48a1-9b33-8e9bba5ff331" />


