### PR TITLE
マップ画面の修正

### DIFF
--- a/src/app/confirm_location/page.tsx
+++ b/src/app/confirm_location/page.tsx
@@ -1,5 +1,28 @@
+"use client";
+
+import { NewLocationCheckScreen } from "@/components/NewLocationCheckScreen";
+
 export default function ConfirmLocation() {
+  const character = {
+    name: "もちもちうさぎ",
+    type: "sakura-san",
+  };
+
+  const handleBack = () => {
+    // 戻るボタンの処理
+    console.log("戻るボタンが押されました");
+  };
+
+  const handleStartBathing = () => {
+    // 入浴開始ボタンの処理
+    console.log("入浴開始ボタンが押されました");
+  };
+
   return (
-    <>温泉探索用のマップ画面</>
-  )
+    <NewLocationCheckScreen
+      character={character}
+      onBack={handleBack}
+      onStartBathing={handleStartBathing}
+    />
+  );
 }

--- a/src/components/NewLocationCheckScreen.tsx
+++ b/src/components/NewLocationCheckScreen.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import { Button } from './ui/button';
-import { Card, CardContent } from './ui/card';
-import { ArrowLeft, MapPin, Navigation } from 'lucide-react';
+import React, { useState, useEffect } from "react";
+import { Button } from "./ui/button";
+import { Card, CardContent } from "./ui/card";
+import { ArrowLeft, MapPin, Navigation } from "lucide-react";
 
-import mapImage from '@/assets/1a0f3b4eaaf666c678218990a5f3915504e73d9c.png';
+import mapImage from "@/assets/1a0f3b4eaaf666c678218990a5f3915504e73d9c.png";
 import beppyonImage from "@/assets/3c6e9e82c814a4dcb5208e61977d5118a50e6a2c.png";
 import yuttsuraImage from "@/assets/cc82c1498637df3406caa6867e011e9f0b8813d7.png";
 import kawaiiImage from "@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png";
@@ -11,7 +11,7 @@ import kawaiiImage from "@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png";
 interface NewLocationCheckScreenProps {
   onBack: () => void;
   onStartBathing: () => void;
-  character: { name: string, type: string };
+  character: { name: string; type: string };
 }
 
 // 温泉の位置データ（箱根湯本温泉の座標）
@@ -22,20 +22,34 @@ const HAKONE_YUMOTO_LNG = 139.1069;
 const SIMULATED_USER_LAT = 35.2318; // 少し南
 const SIMULATED_USER_LNG = 139.1065; // 少し西
 
-export function NewLocationCheckScreen({ onBack, onStartBathing, character }: NewLocationCheckScreenProps) {
-  const [userLocation, setUserLocation] = useState<{ lat: number, lng: number } | null>(null);
+export function NewLocationCheckScreen({
+  onBack,
+  onStartBathing,
+  character,
+}: NewLocationCheckScreenProps) {
+  const [userLocation, setUserLocation] = useState<{
+    lat: number;
+    lng: number;
+  } | null>(null);
   const [isNearOnsen, setIsNearOnsen] = useState(false);
   const [distance, setDistance] = useState<number>(0);
 
   // 距離計算関数（ハバーサイン公式）
-  const calculateDistance = (lat1: number, lng1: number, lat2: number, lng2: number): number => {
+  const calculateDistance = (
+    lat1: number,
+    lng1: number,
+    lat2: number,
+    lng2: number
+  ): number => {
     const R = 6371000; // 地球の半径（メートル）
-    const dLat = (lat2 - lat1) * Math.PI / 180;
-    const dLng = (lng2 - lng1) * Math.PI / 180;
+    const dLat = ((lat2 - lat1) * Math.PI) / 180;
+    const dLng = ((lng2 - lng1) * Math.PI) / 180;
     const a =
       Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-      Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
-      Math.sin(dLng / 2) * Math.sin(dLng / 2);
+      Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
     const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
     return R * c;
   };
@@ -44,7 +58,7 @@ export function NewLocationCheckScreen({ onBack, onStartBathing, character }: Ne
     // 現在地を取得（シミュレーション）
     setUserLocation({
       lat: SIMULATED_USER_LAT,
-      lng: SIMULATED_USER_LNG
+      lng: SIMULATED_USER_LNG,
     });
 
     // 箱根湯本温泉からの距離を計算
@@ -94,7 +108,9 @@ export function NewLocationCheckScreen({ onBack, onStartBathing, character }: Ne
             </div>
             <div className="absolute -bottom-8 left-1/2 transform -translate-x-1/2 whitespace-nowrap">
               <div className="bg-white/90 backdrop-blur-sm px-2 py-1 rounded-lg shadow-md">
-                <span className="text-xs font-bold text-app-base">箱根湯本温泉</span>
+                <span className="text-xs font-bold text-app-base">
+                  箱根湯本温泉
+                </span>
               </div>
             </div>
           </div>
@@ -116,7 +132,9 @@ export function NewLocationCheckScreen({ onBack, onStartBathing, character }: Ne
               {/* 現在地のラベル */}
               <div className="absolute -bottom-10 left-1/2 transform -translate-x-1/2 whitespace-nowrap">
                 <div className="bg-white/90 backdrop-blur-sm px-2 py-1 rounded-lg shadow-md">
-                  <span className="text-xs font-bold text-app-main">現在地</span>
+                  <span className="text-xs font-bold text-app-main">
+                    現在地
+                  </span>
                 </div>
               </div>
 
@@ -152,16 +170,16 @@ export function NewLocationCheckScreen({ onBack, onStartBathing, character }: Ne
               <Navigation className="h-5 w-5 text-app-main mr-2" />
               <div>
                 <p className="font-medium">箱根湯本温泉</p>
-                <p className="text-sm text-app-base-light">
-                  距離: {distance}m
-                </p>
+                <p className="text-sm text-app-base-light">距離: {distance}m</p>
               </div>
             </div>
-            <div className={`px-3 py-1 rounded-full text-xs font-medium ${isNearOnsen
-              ? 'bg-green-100 text-green-800'
-              : 'bg-orange-100 text-orange-800'
-              }`}>
-              {isNearOnsen ? '範囲内' : '範囲外'}
+            <div
+              className={`px-3 py-1 rounded-full text-xs font-medium ${isNearOnsen
+                  ? "bg-green-100 text-green-800"
+                  : "bg-orange-100 text-orange-800"
+                }`}
+            >
+              {isNearOnsen ? "範囲内" : "範囲外"}
             </div>
           </div>
         </CardContent>
@@ -171,10 +189,17 @@ export function NewLocationCheckScreen({ onBack, onStartBathing, character }: Ne
       <Card className="absolute bottom-4 left-4 right-4 z-10">
         <CardContent className="pt-4">
           <div className="text-center">
-            <h3 className="font-bold mb-2 flex justify-center items-center"><MapPin className="mr-2 text-[#F8447E]" /> 位置確認</h3>
+            <h3 className="font-bold mb-2 flex justify-center items-center">
+              <MapPin className="mr-2 text-[#F8447E]" /> 位置確認
+            </h3>
             <div className="space-y-1 text-sm text-app-base-light">
               <p>• 温泉から50m以内で入浴可能</p>
-              <p>• {isNearOnsen ? `\`${character.name}\`が温泉を見つけました！` : 'もう少し温泉に近づいてください'}</p>
+              <p>
+                •{" "}
+                {isNearOnsen
+                  ? `${character.name}が温泉を見つけました！`
+                  : "もう少し温泉に近づいてください"}
+              </p>
             </div>
           </div>
         </CardContent>
@@ -188,7 +213,7 @@ export function NewLocationCheckScreen({ onBack, onStartBathing, character }: Ne
           onClick={onStartBathing}
           disabled={!isNearOnsen}
         >
-          {isNearOnsen ? '入浴する！' : '温泉の近くではありません'}
+          {isNearOnsen ? "入浴する！" : "温泉の近くではありません"}
         </Button>
       </div>
     </div>

--- a/src/components/NewLocationCheckScreen.tsx
+++ b/src/components/NewLocationCheckScreen.tsx
@@ -87,7 +87,7 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
 
         {/* 現在地（もちもちうさぎ） - 温泉の近くに配置 */}
         {userLocation && (
-          <div className="absolute top-1/3 left-1/4 transform -translate-x-1/2 -translate-y-1/2 translate-x-12 translate-y-6">
+          <div className="absolute top-1/3 left-1/4 transform translate-x-12 translate-y-6">
             <div className="relative">
               {/* 位置の円 */}
               <div className="w-14 h-14 bg-app-accent-2 rounded-full border-3 border-white shadow-xl flex items-center justify-center relative overflow-hidden">

--- a/src/components/NewLocationCheckScreen.tsx
+++ b/src/components/NewLocationCheckScreen.tsx
@@ -156,7 +156,7 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
       <Card className="absolute bottom-4 left-4 right-4 z-10">
         <CardContent className="pt-4">
           <div className="text-center">
-            <h3 className="font-bold mb-2">📍 位置確認</h3>
+            <h3 className="font-bold mb-2 flex justify-center items-center"><MapPin className="mr-2 text-[#F8447E]" /> 位置確認</h3>
             <div className="space-y-1 text-sm text-app-base-light">
               <p>• 温泉から50m以内で入浴可能</p>
               <p>• {isNearOnsen ? 'もちもちうさぎが温泉を見つけました！' : 'もう少し温泉に近づいてください'}</p>

--- a/src/components/NewLocationCheckScreen.tsx
+++ b/src/components/NewLocationCheckScreen.tsx
@@ -20,7 +20,7 @@ const SIMULATED_USER_LAT = 35.2318; // 少し南
 const SIMULATED_USER_LNG = 139.1065; // 少し西
 
 export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCheckScreenProps) {
-  const [userLocation, setUserLocation] = useState<{lat: number, lng: number} | null>(null);
+  const [userLocation, setUserLocation] = useState<{ lat: number, lng: number } | null>(null);
   const [isNearOnsen, setIsNearOnsen] = useState(false);
   const [distance, setDistance] = useState<number>(0);
 
@@ -29,11 +29,11 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
     const R = 6371000; // 地球の半径（メートル）
     const dLat = (lat2 - lat1) * Math.PI / 180;
     const dLng = (lng2 - lng1) * Math.PI / 180;
-    const a = 
-      Math.sin(dLat/2) * Math.sin(dLat/2) +
+    const a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
       Math.cos(lat1 * Math.PI / 180) * Math.cos(lat2 * Math.PI / 180) *
-      Math.sin(dLng/2) * Math.sin(dLng/2);
-    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+      Math.sin(dLng / 2) * Math.sin(dLng / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
     return R * c;
   };
 
@@ -51,7 +51,7 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
       HAKONE_YUMOTO_LAT,
       HAKONE_YUMOTO_LNG
     );
-    
+
     setDistance(Math.round(dist));
     setIsNearOnsen(dist <= 500); // 500m以内なら温泉の近く
   }, []);
@@ -63,9 +63,9 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
       {/* マップエリア - 画面全体 */}
       <div className="absolute inset-0">
         {/* 地図画像背景 */}
-        <img 
-          src={mapImage} 
-          alt="箱根エリア地図" 
+        <img
+          src={mapImage.src}
+          alt="箱根エリア地図"
           className="absolute inset-0 w-full h-full object-cover object-center"
         />
         {/* 地図の上にオーバーレイ */}
@@ -92,12 +92,12 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
               {/* 位置の円 */}
               <div className="w-14 h-14 bg-app-accent-2 rounded-full border-3 border-white shadow-xl flex items-center justify-center relative overflow-hidden">
                 <img
-                  src={kawaiiImage}
+                  src={kawaiiImage.src}
                   alt="もちもちうさぎ"
                   className="w-11 h-11 object-contain"
                 />
               </div>
-              
+
               {/* 現在地のラベル */}
               <div className="absolute -bottom-10 left-1/2 transform -translate-x-1/2 whitespace-nowrap">
                 <div className="bg-white/90 backdrop-blur-sm px-2 py-1 rounded-lg shadow-md">
@@ -120,7 +120,7 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
           </div>
         )}
       </div>
-      
+
       {/* ヘッダー - オーバーレイ */}
       <div className="absolute top-0 left-0 right-0 z-10 flex items-center p-4 bg-white/80 backdrop-blur-sm">
         <Button variant="ghost" onClick={onBack} className="mr-2 p-2">
@@ -142,11 +142,10 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
                 </p>
               </div>
             </div>
-            <div className={`px-3 py-1 rounded-full text-xs font-medium ${
-              isNearOnsen 
-                ? 'bg-green-100 text-green-800' 
+            <div className={`px-3 py-1 rounded-full text-xs font-medium ${isNearOnsen
+                ? 'bg-green-100 text-green-800'
                 : 'bg-orange-100 text-orange-800'
-            }`}>
+              }`}>
               {isNearOnsen ? '範囲内' : '範囲外'}
             </div>
           </div>

--- a/src/components/NewLocationCheckScreen.tsx
+++ b/src/components/NewLocationCheckScreen.tsx
@@ -3,12 +3,15 @@ import { Button } from './ui/button';
 import { Card, CardContent } from './ui/card';
 import { ArrowLeft, MapPin, Navigation } from 'lucide-react';
 
-import kawaiiImage from '@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png';
 import mapImage from '@/assets/1a0f3b4eaaf666c678218990a5f3915504e73d9c.png';
+import beppyonImage from "@/assets/3c6e9e82c814a4dcb5208e61977d5118a50e6a2c.png";
+import yuttsuraImage from "@/assets/cc82c1498637df3406caa6867e011e9f0b8813d7.png";
+import kawaiiImage from "@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png";
 
 interface NewLocationCheckScreenProps {
   onBack: () => void;
   onStartBathing: () => void;
+  character: { name: string, type: string };
 }
 
 // 温泉の位置データ（箱根湯本温泉の座標）
@@ -19,7 +22,7 @@ const HAKONE_YUMOTO_LNG = 139.1069;
 const SIMULATED_USER_LAT = 35.2318; // 少し南
 const SIMULATED_USER_LNG = 139.1065; // 少し西
 
-export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCheckScreenProps) {
+export function NewLocationCheckScreen({ onBack, onStartBathing, character }: NewLocationCheckScreenProps) {
   const [userLocation, setUserLocation] = useState<{ lat: number, lng: number } | null>(null);
   const [isNearOnsen, setIsNearOnsen] = useState(false);
   const [distance, setDistance] = useState<number>(0);
@@ -56,7 +59,19 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
     setIsNearOnsen(dist <= 500); // 500m以内なら温泉の近く
   }, []);
 
-
+  // キャラクターの種類に応じて画像を選択
+  const getCharacterImage = () => {
+    switch (character.type) {
+      case "onsen-chan":
+        return beppyonImage;
+      case "yuzu-kun":
+        return yuttsuraImage;
+      case "sakura-san":
+        return kawaiiImage;
+      default:
+        return beppyonImage;
+    }
+  };
 
   return (
     <div className="h-screen relative overflow-hidden">
@@ -92,7 +107,7 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
               {/* 位置の円 */}
               <div className="w-14 h-14 bg-app-accent-2 rounded-full border-3 border-white shadow-xl flex items-center justify-center relative overflow-hidden">
                 <img
-                  src={kawaiiImage.src}
+                  src={getCharacterImage().src}
                   alt="もちもちうさぎ"
                   className="w-11 h-11 object-contain"
                 />
@@ -143,8 +158,8 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
               </div>
             </div>
             <div className={`px-3 py-1 rounded-full text-xs font-medium ${isNearOnsen
-                ? 'bg-green-100 text-green-800'
-                : 'bg-orange-100 text-orange-800'
+              ? 'bg-green-100 text-green-800'
+              : 'bg-orange-100 text-orange-800'
               }`}>
               {isNearOnsen ? '範囲内' : '範囲外'}
             </div>
@@ -159,7 +174,7 @@ export function NewLocationCheckScreen({ onBack, onStartBathing }: NewLocationCh
             <h3 className="font-bold mb-2 flex justify-center items-center"><MapPin className="mr-2 text-[#F8447E]" /> 位置確認</h3>
             <div className="space-y-1 text-sm text-app-base-light">
               <p>• 温泉から50m以内で入浴可能</p>
-              <p>• {isNearOnsen ? 'もちもちうさぎが温泉を見つけました！' : 'もう少し温泉に近づいてください'}</p>
+              <p>• {isNearOnsen ? `\`${character.name}\`が温泉を見つけました！` : 'もう少し温泉に近づいてください'}</p>
             </div>
           </div>
         </CardContent>


### PR DESCRIPTION
closes #20 

## やったこと

- [http://localhost:3000/confirm_location](http://localhost:3000/confirm_location)でマップ画面を確認できるようにした
- キャラクターの名前と画像を引数から呼び出せるように修正
- 画像読み込みの正常化
- 使用されていないimportや変数の削除
- キャラクターの画像の表示ロジックの修正
- lucideによる絵文字の代替

## レビューしてほしいこと

- Figma Makeと同じ挙動になっているかどうか
- イベントハンドラが全て正常に発火すること
- キャラクターの画像の表示ロジック（`src/components/NewLocationCheckScreen.tsx`における`getCharacterImage`を用いた処理）に問題はないか

## 備考
マップの表示ロジックに関しては指示があったのでモックのままにしてあります。

## 作業結果の参考画像
<img width="358" height="753" alt="SS 70" src="https://github.com/user-attachments/assets/e00e3459-da51-4ce3-b3b7-3c580c105b3d" />


