### PR TITLE
スタンプ獲得画面を修正

### DIFF
--- a/src/app/get_stamp/page.tsx
+++ b/src/app/get_stamp/page.tsx
@@ -1,5 +1,19 @@
+"use client";
+
+import { StampAcquisitionScreen } from "@/components/StampAcquisitionScreen";
+import stampImage from "@/assets/23d72f267674d7a86e5a4d3966ba367d52634bd9.png";
+
 export default function GetStamp() {
+  const handleComplete = () => {
+    console.log("スタンプ獲得完了");
+  };
+
+  const acquiredStamp = { name: "温泉スタンプ", icon: stampImage.src };
+
   return (
-    <>スタンプ獲得画面</>
-  )
+    <StampAcquisitionScreen
+      onComplete={handleComplete}
+      acquiredStamp={acquiredStamp}
+    />
+  );
 }

--- a/src/components/StampAcquisitionScreen.tsx
+++ b/src/components/StampAcquisitionScreen.tsx
@@ -31,7 +31,7 @@ export function StampAcquisitionScreen({ onComplete }: StampAcquisitionScreenPro
   };
 
   return (
-    <div 
+    <div
       className="min-h-screen bg-white flex flex-col items-center justify-center p-4 relative overflow-hidden"
       onClick={handleScreenTap}
     >
@@ -62,8 +62,8 @@ export function StampAcquisitionScreen({ onComplete }: StampAcquisitionScreenPro
           <motion.div
             initial={{ scale: 50, opacity: 0.8 }}
             animate={{ scale: 1, opacity: 1 }}
-            transition={{ 
-              duration: 1, 
+            transition={{
+              duration: 1,
               ease: "easeIn"
             }}
             className="relative"
@@ -72,7 +72,7 @@ export function StampAcquisitionScreen({ onComplete }: StampAcquisitionScreenPro
             {/* スタンプ画像 */}
             <div className="relative">
               <img
-                src={stampImage}
+                src={stampImage.src}
                 alt="温泉スタンプ"
                 className="w-48 h-48 object-contain relative z-10"
                 style={{
@@ -83,32 +83,15 @@ export function StampAcquisitionScreen({ onComplete }: StampAcquisitionScreenPro
                   `,
                 }}
               />
-              
+
               {/* 白いノイズテクスチャオーバーレイ */}
-              <div 
+              <div
                 className="absolute inset-0 w-48 h-48 opacity-25 pointer-events-none z-20"
                 style={{
                   backgroundImage: `url(${noiseTexture})`,
                   backgroundSize: '200px 200px',
                   backgroundRepeat: 'repeat',
                   mixBlendMode: 'screen',
-                  mask: `url(${stampImage})`,
-                  maskSize: 'contain',
-                  maskRepeat: 'no-repeat',
-                  maskPosition: 'center',
-                  WebkitMask: `url(${stampImage})`,
-                  WebkitMaskSize: 'contain',
-                  WebkitMaskRepeat: 'no-repeat',
-                  WebkitMaskPosition: 'center'
-                }}
-              />
-
-              {/* 印影効果 */}
-              <div 
-                className="absolute inset-0 w-48 h-48 opacity-25 pointer-events-none z-15"
-                style={{
-                  background: `radial-gradient(ellipse at center, transparent 50%, rgba(93, 104, 138, 0.4) 65%, rgba(93, 104, 138, 0.6) 75%, transparent 90%)`,
-                  mixBlendMode: 'multiply',
                   mask: `url(${stampImage})`,
                   maskSize: 'contain',
                   maskRepeat: 'no-repeat',

--- a/src/components/StampAcquisitionScreen.tsx
+++ b/src/components/StampAcquisitionScreen.tsx
@@ -89,7 +89,7 @@ export function StampAcquisitionScreen({
               <div
                 className="absolute inset-0 w-48 h-48 opacity-25 pointer-events-none z-20"
                 style={{
-                  backgroundImage: `url(${noiseTexture})`,
+                  backgroundImage: `url(${noiseTexture.src})`,
                   backgroundSize: "200px 200px",
                   backgroundRepeat: "repeat",
                   mixBlendMode: "screen",

--- a/src/components/StampAcquisitionScreen.tsx
+++ b/src/components/StampAcquisitionScreen.tsx
@@ -1,13 +1,16 @@
-import React, { useState, useEffect } from 'react';
-import { motion } from 'motion/react';
-import stampImage from '@/assets/23d72f267674d7a86e5a4d3966ba367d52634bd9.png';
-import noiseTexture from '@/assets/221bcc06007de28e2dedf86e88d0a2798eac78e7.png';
+import React, { useState, useEffect } from "react";
+import { motion } from "motion/react";
+import noiseTexture from "@/assets/221bcc06007de28e2dedf86e88d0a2798eac78e7.png";
 
 interface StampAcquisitionScreenProps {
   onComplete: () => void;
+  acquiredStamp: { name: string; icon: string };
 }
 
-export function StampAcquisitionScreen({ onComplete }: StampAcquisitionScreenProps) {
+export function StampAcquisitionScreen({
+  onComplete,
+  acquiredStamp,
+}: StampAcquisitionScreenProps) {
   const [stampAnimationComplete, setStampAnimationComplete] = useState(false);
   const [showTapMessage, setShowTapMessage] = useState(false);
   const [canInteract, setCanInteract] = useState(false);
@@ -52,9 +55,7 @@ export function StampAcquisitionScreen({ onComplete }: StampAcquisitionScreenPro
           transition={{ duration: 0.5 }}
           className="mb-8"
         >
-          <h1 className="text-2xl text-center text-app-base">
-            スタンプ獲得！
-          </h1>
+          <h1 className="text-2xl text-center text-app-base">スタンプ獲得！</h1>
         </motion.div>
 
         {/* スタンプアニメーション */}
@@ -64,7 +65,7 @@ export function StampAcquisitionScreen({ onComplete }: StampAcquisitionScreenPro
             animate={{ scale: 1, opacity: 1 }}
             transition={{
               duration: 1,
-              ease: "easeIn"
+              ease: "easeIn",
             }}
             className="relative"
             onAnimationComplete={() => setStampAnimationComplete(true)}
@@ -72,8 +73,8 @@ export function StampAcquisitionScreen({ onComplete }: StampAcquisitionScreenPro
             {/* スタンプ画像 */}
             <div className="relative">
               <img
-                src={stampImage.src}
-                alt="温泉スタンプ"
+                src={acquiredStamp.icon}
+                alt={acquiredStamp.name}
                 className="w-48 h-48 object-contain relative z-10"
                 style={{
                   filter: `
@@ -89,17 +90,17 @@ export function StampAcquisitionScreen({ onComplete }: StampAcquisitionScreenPro
                 className="absolute inset-0 w-48 h-48 opacity-25 pointer-events-none z-20"
                 style={{
                   backgroundImage: `url(${noiseTexture})`,
-                  backgroundSize: '200px 200px',
-                  backgroundRepeat: 'repeat',
-                  mixBlendMode: 'screen',
-                  mask: `url(${stampImage})`,
-                  maskSize: 'contain',
-                  maskRepeat: 'no-repeat',
-                  maskPosition: 'center',
-                  WebkitMask: `url(${stampImage})`,
-                  WebkitMaskSize: 'contain',
-                  WebkitMaskRepeat: 'no-repeat',
-                  WebkitMaskPosition: 'center'
+                  backgroundSize: "200px 200px",
+                  backgroundRepeat: "repeat",
+                  mixBlendMode: "screen",
+                  mask: `url(${acquiredStamp.icon})`,
+                  maskSize: "contain",
+                  maskRepeat: "no-repeat",
+                  maskPosition: "center",
+                  WebkitMask: `url(${acquiredStamp.icon})`,
+                  WebkitMaskSize: "contain",
+                  WebkitMaskRepeat: "no-repeat",
+                  WebkitMaskPosition: "center",
                 }}
               />
             </div>


### PR DESCRIPTION
closes #22 

## やったこと

- [http://localhost:3000/get_stamp](http://localhost:3000/get_stamp)でスタンプ獲得画面を確認できるようにした
- 獲得するスタンプを引数化
- 画像読み込みの正常化
- スタンプ背景の陰影の削除

## レビューしてほしいこと

- Figma Makeと同じ挙動になっているかどうか
- イベントハンドラが全て正常に発火すること

## 備考

## 作業結果の参考画像
<img width="358" height="749" alt="image" src="https://github.com/user-attachments/assets/0b2702d5-837a-4f5d-bfb4-9fa6875ac643" />



