### PR TITLE
キャラクター選択・命名画面の修正

### DIFF
--- a/src/app/set_character_name/page.tsx
+++ b/src/app/set_character_name/page.tsx
@@ -1,5 +1,37 @@
+"use client";
+
+import { CharacterNameInputScreen } from "@/components/CharacterNameInputScreen";
+import kawaiiImage from '@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png';
+
 export default function SetCharacterName() {
+
+  const userName = "ユーザー名";
+  const character = {
+    id: "sakura-san",
+    name: "もちもちうさぎだよ",
+    description: "あなたの温泉パートナー",
+    image: kawaiiImage
+  };
+
+  const handleBack = () => {
+    console.log("Back button clicked");
+  };
+
+  const handleCharacterNameChange = (name: string) => {
+    console.log("Character name changed to:", name);
+  };
+
+  const handleComplete = () => {
+    console.log("Character naming completed");
+  };
+
   return (
-    <>パートナーキャラの選択・命名画面</>
+    <CharacterNameInputScreen
+      userName={userName}
+      character={character}
+      onBack={handleBack}
+      onCharacterNameChange={handleCharacterNameChange}
+      onComplete={handleComplete}
+    />
   )
 }

--- a/src/app/set_character_name/page.tsx
+++ b/src/app/set_character_name/page.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import { CharacterNameInputScreen } from "@/components/CharacterNameInputScreen";
-import kawaiiImage from '@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png';
+import kawaiiImage from "@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png";
 
 export default function SetCharacterName() {
-
   const userName = "ユーザー名";
   const character = {
     id: "sakura-san",
     name: "もちもちうさぎだよ",
     description: "あなたの温泉パートナー",
-    image: kawaiiImage
+    image: kawaiiImage,
   };
 
   const handleBack = () => {
@@ -28,10 +27,9 @@ export default function SetCharacterName() {
   return (
     <CharacterNameInputScreen
       userName={userName}
-      character={character}
       onBack={handleBack}
       onCharacterNameChange={handleCharacterNameChange}
       onComplete={handleComplete}
     />
-  )
+  );
 }

--- a/src/app/set_character_name/page.tsx
+++ b/src/app/set_character_name/page.tsx
@@ -26,6 +26,7 @@ export default function SetCharacterName() {
 
   return (
     <CharacterNameInputScreen
+      character={character}
       userName={userName}
       onBack={handleBack}
       onCharacterNameChange={handleCharacterNameChange}

--- a/src/components/CharacterNameInputScreen.tsx
+++ b/src/components/CharacterNameInputScreen.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import { Button } from './ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Card, CardContent } from './ui/card';
 import { Input } from './ui/input';
-import { ImageWithFallback } from './figma/ImageWithFallback';
 import { ArrowLeft } from 'lucide-react';
 import kawaiiImage from '@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png';
 
@@ -89,8 +88,8 @@ export function CharacterNameInputScreen({ userName, characterName = '', onBack,
             </CardContent>
           </Card>
 
-          <Button 
-            size="lg" 
+          <Button
+            size="lg"
             className="w-full"
             onClick={handleComplete}
             disabled={!inputName.trim()}

--- a/src/components/CharacterNameInputScreen.tsx
+++ b/src/components/CharacterNameInputScreen.tsx
@@ -58,7 +58,7 @@ export function CharacterNameInputScreen({ userName, characterName = '', onBack,
               <div className="flex flex-col items-center text-center">
                 <div className="w-24 h-24 rounded-full mb-4 overflow-hidden bg-app-accent-2 flex items-center justify-center shadow-lg">
                   <img
-                    src={defaultCharacter.image}
+                    src={defaultCharacter.image.src}
                     alt="パートナーキャラクター"
                     className="w-20 h-20 object-contain"
                   />

--- a/src/components/CharacterNameInputScreen.tsx
+++ b/src/components/CharacterNameInputScreen.tsx
@@ -4,10 +4,16 @@ import { Card, CardContent } from './ui/card';
 import { Input } from './ui/input';
 import { ArrowLeft } from 'lucide-react';
 import kawaiiImage from '@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png';
+import { StaticImageData } from '../../node_modules/next/image';
 
 interface CharacterNameInputScreenProps {
   userName: string;
-  characterName?: string;
+  character?: {
+    id: string;
+    name: string;
+    description: string;
+    image: StaticImageData;
+  };
   onBack: () => void;
   onCharacterNameChange: (name: string) => void;
   onComplete: () => void;
@@ -15,13 +21,13 @@ interface CharacterNameInputScreenProps {
 
 const defaultCharacter = {
   id: 'sakura-san',
-  defaultName: 'もちもちうさぎ',
+  name: 'もちもちうさぎ',
   description: 'あなたの温泉パートナー',
   image: kawaiiImage
 };
 
-export function CharacterNameInputScreen({ userName, characterName = '', onBack, onCharacterNameChange, onComplete }: CharacterNameInputScreenProps) {
-  const [inputName, setInputName] = useState(characterName || defaultCharacter.defaultName);
+export function CharacterNameInputScreen({ userName, character, onBack, onCharacterNameChange, onComplete }: CharacterNameInputScreenProps) {
+  const [inputName, setInputName] = useState(character?.name || defaultCharacter.name);
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newName = e.target.value;
@@ -58,12 +64,12 @@ export function CharacterNameInputScreen({ userName, characterName = '', onBack,
               <div className="flex flex-col items-center text-center">
                 <div className="w-24 h-24 rounded-full mb-4 overflow-hidden bg-app-accent-2 flex items-center justify-center shadow-lg">
                   <img
-                    src={defaultCharacter.image.src}
+                    src={character?.image.src || defaultCharacter.image.src}
                     alt="パートナーキャラクター"
                     className="w-20 h-20 object-contain"
                   />
                 </div>
-                <p className="text-app-base-light mb-4">{defaultCharacter.description}</p>
+                <p className="text-app-base-light mb-4">{character?.description || defaultCharacter.description}</p>
               </div>
             </CardContent>
           </Card>

--- a/src/components/CharacterNameInputScreen.tsx
+++ b/src/components/CharacterNameInputScreen.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
-import { Button } from './ui/button';
-import { Card, CardContent } from './ui/card';
-import { Input } from './ui/input';
-import { ArrowLeft } from 'lucide-react';
-import kawaiiImage from '@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png';
-import { StaticImageData } from '../../node_modules/next/image';
+import React, { useState } from "react";
+import { Button } from "./ui/button";
+import { Card, CardContent } from "./ui/card";
+import { Input } from "./ui/input";
+import { ArrowLeft } from "lucide-react";
+import kawaiiImage from "@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png";
+import { StaticImageData } from "../../node_modules/next/image";
 
 interface CharacterNameInputScreenProps {
   userName: string;
@@ -20,14 +20,22 @@ interface CharacterNameInputScreenProps {
 }
 
 const defaultCharacter = {
-  id: 'sakura-san',
-  name: 'もちもちうさぎ',
-  description: 'あなたの温泉パートナー',
-  image: kawaiiImage
+  id: "sakura-san",
+  name: "もちもちうさぎ",
+  description: "あなたの温泉パートナー",
+  image: kawaiiImage,
 };
 
-export function CharacterNameInputScreen({ userName, character, onBack, onCharacterNameChange, onComplete }: CharacterNameInputScreenProps) {
-  const [inputName, setInputName] = useState(character?.name || defaultCharacter.name);
+export function CharacterNameInputScreen({
+  userName, //現状使われていないが、バックの処理で必要になる可能性があるためpropsとして受け取る
+  character,
+  onBack,
+  onCharacterNameChange,
+  onComplete,
+}: CharacterNameInputScreenProps) {
+  const [inputName, setInputName] = useState(
+    character?.name || defaultCharacter.name
+  );
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newName = e.target.value;
@@ -45,7 +53,12 @@ export function CharacterNameInputScreen({ userName, character, onBack, onCharac
     <div className="min-h-screen bg-gradient-to-b from-app-base via-app-main-dark to-app-main relative">
       {/* Back button - fixed to top left */}
       <div className="absolute top-6 left-6 z-10">
-        <Button variant="ghost" size="icon" onClick={onBack} className="bg-white/20 hover:bg-white/30">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onBack}
+          className="bg-white/20 hover:bg-white/30"
+        >
           <ArrowLeft className="w-5 h-5 text-white" />
         </Button>
       </div>
@@ -55,7 +68,9 @@ export function CharacterNameInputScreen({ userName, character, onBack, onCharac
         <div className="max-w-md w-full">
           {/* Header */}
           <div className="text-center mb-8">
-            <h1 className="text-2xl font-bold text-white mb-2">この子の名前は？</h1>
+            <h1 className="text-2xl font-bold text-white mb-2">
+              この子の名前は？
+            </h1>
           </div>
 
           {/* Character Display */}
@@ -69,7 +84,9 @@ export function CharacterNameInputScreen({ userName, character, onBack, onCharac
                     className="w-20 h-20 object-contain"
                   />
                 </div>
-                <p className="text-app-base-light mb-4">{character?.description || defaultCharacter.description}</p>
+                <p className="text-app-base-light mb-4">
+                  {character?.description || defaultCharacter.description}
+                </p>
               </div>
             </CardContent>
           </Card>

--- a/src/components/CharacterNameInputScreen.tsx
+++ b/src/components/CharacterNameInputScreen.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent } from "./ui/card";
 import { Input } from "./ui/input";
 import { ArrowLeft } from "lucide-react";
 import kawaiiImage from "@/assets/ac6d9ab22063d00cb690b5d70df3dad88375e1a0.png";
-import { StaticImageData } from "../../node_modules/next/image";
+import { StaticImageData } from "next/image";
 
 interface CharacterNameInputScreenProps {
   userName: string;

--- a/src/components/CharacterNameInputScreen.tsx
+++ b/src/components/CharacterNameInputScreen.tsx
@@ -28,14 +28,12 @@ const defaultCharacter = {
 
 export function CharacterNameInputScreen({
   userName, //現状使われていないが、バックの処理で必要になる可能性があるためpropsとして受け取る
-  character,
+  character = defaultCharacter,
   onBack,
   onCharacterNameChange,
   onComplete,
 }: CharacterNameInputScreenProps) {
-  const [inputName, setInputName] = useState(
-    character?.name || defaultCharacter.name
-  );
+  const [inputName, setInputName] = useState(character.name);
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newName = e.target.value;
@@ -79,13 +77,13 @@ export function CharacterNameInputScreen({
               <div className="flex flex-col items-center text-center">
                 <div className="w-24 h-24 rounded-full mb-4 overflow-hidden bg-app-accent-2 flex items-center justify-center shadow-lg">
                   <img
-                    src={character?.image.src || defaultCharacter.image.src}
+                    src={character.image.src}
                     alt="パートナーキャラクター"
                     className="w-20 h-20 object-contain"
                   />
                 </div>
                 <p className="text-app-base-light mb-4">
-                  {character?.description || defaultCharacter.description}
+                  {character.description}
                 </p>
               </div>
             </CardContent>


### PR DESCRIPTION
closes #18 

## やったこと

- [http://localhost:3000/set_character_name](http://localhost:3000/set_character_name)でキャラクター選択・命名画面を確認できるようにした
- キャラクター情報を引数化
- 画像読み込みの正常化

## レビューしてほしいこと

- Figma Makeと同じ挙動になっているかどうか
- イベントハンドラが全て正常に発火すること
- キャラクター情報の暫定的な扱いは適切か

## 備考
- キャラクターの情報をどうやって扱うか上手い案が現状だと思い付かなかったので、ひとまずdefaultCharacterを初期値として全て引数化しておきました。
- 現状だと選択できるキャラクターがもちもちうさぎだけなので、キャラクター選択を行えるUIを実装する必要があると感じました。

## 作業結果の参考画像
<img width="335" height="744" alt="image" src="https://github.com/user-attachments/assets/9c8735a5-1d9d-4f44-958f-7f7d4a1dcdd1" />



