### PR TITLE
57 inactivate any nav

### DIFF
--- a/src/components/BottomTabNavigation.tsx
+++ b/src/components/BottomTabNavigation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Home, Settings, Droplets } from 'lucide-react';
 
-export type TabType = 'home' | 'bathing' | 'settings';
+export type TabType = 'home' | 'bathing' | 'settings' | 'none';
 
 interface BottomTabNavigationProps {
   activeTab: TabType;

--- a/src/components/CharacterDecoScreen.tsx
+++ b/src/components/CharacterDecoScreen.tsx
@@ -135,7 +135,7 @@ export function CharacterDecoScreen({ onBack, character, onTabChange }: Characte
       </div>
       
       <BottomTabNavigation 
-        activeTab="settings" 
+        activeTab="none" 
         onTabChange={handleTabChange}
       />
     </div>

--- a/src/components/QuestScreen.tsx
+++ b/src/components/QuestScreen.tsx
@@ -208,7 +208,7 @@ export function StampRallyScreen({ onBack, onSelectQuest, onTabChange }: QuestLi
       </div>
       
       <BottomTabNavigation 
-        activeTab="bathing" 
+        activeTab="none" 
         onTabChange={handleTabChange}
       />
     </div>


### PR DESCRIPTION
## やったこと

- ナビゲーションバーで，どのナビゲーションもアクティブでないことを示せるようにした
- 「クエスト画面」「キャラクターデコレーション画面」を表示しているとき，どのナビゲーションもアクティブにしないようにした

## 備考

|<img width="400" height="859" alt="image" src="https://github.com/user-attachments/assets/d8bb8046-3afd-4362-b3ca-643d84654c2d" />|<img width="399" height="858" alt="image" src="https://github.com/user-attachments/assets/f1c002f6-4d9c-4df1-bbbc-3c85b4787835" />|
|:-:|:-:|
|クエスト画面|キャラクターデコレーション画面|
