### PR TITLE
タイマー内のレベルと温泉回数を削除

### DIFF
--- a/src/components/TimerScreen.tsx
+++ b/src/components/TimerScreen.tsx
@@ -271,16 +271,6 @@ export function TimerScreen({ character, onComplete, onCancel }: TimerScreenProp
               </div>
               
               <h2 className="text-xl font-bold text-app-base mb-2">{character.name}</h2>
-              <div className="flex justify-center space-x-4 text-sm">
-                <div className="text-center">
-                  <p className="text-app-base-light">レベル</p>
-                  <p className="font-bold text-app-main">{character.level}</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-app-base-light">温泉回数</p>
-                  <p className="font-bold text-app-main">{character.onsenCount}</p>
-                </div>
-              </div>
               
               {isRunning && (
                 <div className="mt-4 p-3 bg-white/95 rounded-lg shadow-md border border-white/20">


### PR DESCRIPTION
## やったこと
タイマー内のレベルと温泉回数を削除してUIをスッキリさせた。

## 参考画像
<img width="550" height="831" alt="SS 86" src="https://github.com/user-attachments/assets/3108e8c8-84b2-42c1-bdbb-151fe86f523a" />
