### PR TITLE
preloadに対応できるように背景を別で定義

### DIFF
--- a/src/components/TimerScreen.tsx
+++ b/src/components/TimerScreen.tsx
@@ -108,7 +108,7 @@ export function TimerScreen({ character, onComplete, onCancel }: TimerScreenProp
   const currentTimerColor = getTimerTextColor(timeElapsed);
 
   return (
-    <div className="min-h-screen relative overflow-hidden">
+    <div className="min-h-screen p-4 relative overflow-hidden">
       <img
         src={backgroundImage.src}
         alt="Background"


### PR DESCRIPTION
divタグのbackgroundに画像を設定するとpreloadが適応されず読み込みが遅いままなので、別で定義しました。